### PR TITLE
Fix broken template blocks

### DIFF
--- a/templates/inventario/formulario_producto.html
+++ b/templates/inventario/formulario_producto.html
@@ -8,7 +8,7 @@ Formulario Productos
 {% block content %}
 
 
-<h2>{% if form.instace.pk %} Editar {% else %} Crear {% endif %} </h2>
+<h2>{% if form.instance.pk %} Editar {% else %} Crear {% endif %} </h2>
 
 <form method="post">
     {% csrf_token %}

--- a/templates/inventario/productos.html
+++ b/templates/inventario/productos.html
@@ -4,7 +4,7 @@
 Productos Disponible
 {% endblock title %}
 
-{{% block content %}
+{% block content %}
 
 <h2>Productos disponibles</h2>
 <table class="table table-bordered">
@@ -44,4 +44,4 @@ Productos Disponible
 
 
 
-{% endblock content %}}
+{% endblock content %}

--- a/templates/ventas/listado_clientes.html
+++ b/templates/ventas/listado_clientes.html
@@ -4,7 +4,7 @@
 Listado Cliente
 {% endblock title %}
 
-{{% block content %}
+{% block content %}
 
 <h2>Clientes</h2>
 <table class="table table-bordered">
@@ -33,4 +33,4 @@ Listado Cliente
 
 
 
-{% endblock content %}}
+{% endblock content %}

--- a/templates/ventas/listado_ventas.html
+++ b/templates/ventas/listado_ventas.html
@@ -4,7 +4,7 @@
 Listado Venta
 {% endblock title %}
 
-{{% block content %}
+{% block content %}
 
 <h2>Ventas</h2>
 <table class="table table-bordered">
@@ -28,4 +28,4 @@ Listado Venta
   </tbody>
 </table>
 
-{% endblock content %}}
+{% endblock content %}


### PR DESCRIPTION
## Summary
- fix typo `instace` in product form template
- correct block tags in product listing and sales templates

## Testing
- `python manage.py check` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_683faeaac2948331a2944da000caa75f